### PR TITLE
Move Firebase config to a module

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,10 @@
+export const firebaseConfig = {
+  apiKey: "AIzaSyBRz_YHWRurV0ZazilVra-chyp70CXyuIY",
+  authDomain: "color-war-4b8ee.firebaseapp.com",
+  projectId: "color-war-4b8ee",
+  storageBucket: "color-war-4b8ee.appspot.com",
+  messagingSenderId: "987787983661",
+  appId: "1:987787983661:web:3fcfe121bebb6f4b7f6b1a",
+  measurementId: "G-YNHTF1VLXF"
+};
+

--- a/main.py
+++ b/main.py
@@ -90,11 +90,11 @@
         import { getFirestore, doc, getDoc, setDoc, onSnapshot, updateDoc, arrayUnion, runTransaction } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
         import * as THREE from 'three';
         import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+        import { firebaseConfig } from './firebase-config.js';
 
         const GRID_SIZE = 15, GAME_DURATION_SECONDS = 300, PIXEL_CLICK_COOLDOWN = 250;
         const PLAYER_COLORS = ["#FF5733", "#33FF57", "#3357FF", "#FF33A1", "#A133FF", "#33FFA1", "#FFD700", "#00FFFF"];
         
-        const firebaseConfig = JSON.parse(typeof __firebase_config !== 'undefined' ? __firebase_config : '{}');
         const appId = typeof __app_id !== 'undefined' ? __app_id : 'default-color-wars-3d';
         const DB_PATH = `artifacts/${appId}/public/data/color-wars-3d-games`;
 
@@ -389,7 +389,11 @@
         playAgainBtn.addEventListener('click', resetToLobby); canvasContainer.addEventListener('click', handleCanvasClick);
         window.addEventListener('resize', onWindowResize);
 
-        initialize();
+        if (!firebaseConfig || Object.keys(firebaseConfig).length === 0) {
+            alert('⚠️ Firebase غير مفعّل');
+        } else {
+            initialize();
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move firebase configuration into `firebase-config.js`
- import the config in the main page and warn if missing

## Testing
- `node -e "import('./firebase-config.js').then(m=>console.log(m.firebaseConfig.apiKey))"`


------
https://chatgpt.com/codex/tasks/task_e_684961d9470c8329b32ab0aadeee5c58