### PR TITLE
Implement winner modal after game ends

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
                     renderGameBoard(gameData);
                     if (gameData.status === 'finished') {
                         if (!gameData.winner && userId === gameData.host) calculateAndSetWinner(gameData);
-                        if (!winnerModal.classList.contains('flex')) showWinner(gameData);
+                        if (gameData.winner) showWinner(gameData);
                     }
                 }
             }
@@ -364,11 +364,16 @@
         }
         
         function showWinner(gameData) {
-            if (winnerModal.classList.contains('flex')) return;
-            if (gameData.winner === 'tie') { winnerTitle.textContent = "👑 تعادل! 👑"; winnerMessage.textContent = "لقد كانت معركة شرسة وانتهت بالتعادل!"; }
-            else {
+            if (!gameData.winner) return;
+            if (gameData.winner === 'tie') {
+                winnerTitle.textContent = "👑 تعادل! 👑";
+                winnerMessage.textContent = "لقد كانت معركة شرسة وانتهت بالتعادل!";
+            } else {
                 const winnerInfo = gameData.players.find(p => p.uid === gameData.winner);
-                if (winnerInfo) { winnerTitle.textContent = "🎉 الفائز هو! 🎉"; winnerMessage.innerHTML = `اللاعب <span class="font-bold" style="color:${PLAYER_COLORS[winnerInfo.colorIndex]}">${winnerInfo.name}</span> هو المسيطر على اللوحة!`; }
+                if (winnerInfo) {
+                    winnerTitle.textContent = "🎉 الفائز هو! 🎉";
+                    winnerMessage.innerHTML = `اللاعب <span class="font-bold" style="color:${PLAYER_COLORS[winnerInfo.colorIndex]}">${winnerInfo.name}</span> هو المسيطر على اللوحة!`;
+                }
             }
             winnerModal.classList.remove('hidden');
             winnerModal.classList.add('flex');


### PR DESCRIPTION
## Summary
- display the winner only when the result is calculated
- update winner modal text every time status updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849be1b6b6883298a4a5d378485e635